### PR TITLE
allow usage inside Sourcegraph

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,13 @@ ENV GOPATH /usr/local
 # Allow determining whether we're running in Docker
 ENV IN_DOCKER_CONTAINER true
 
-# Add this toolchain
-ADD .bin /srclib/srclib-basic/
-WORKDIR /srclib/srclib-basic
-ENV PATH /srclib/srclib-basic/:$PATH
+ENV SRCLIBPATH /srclib
+ADD Srclibtoolchain /srclib/srclib-basic/
+ADD .bin /srclib/srclib-basic/.bin
 
 # Add srclib (unprivileged) user
 RUN adduser -D -s /bin/bash srclib
-RUN mkdir /src
-RUN chown -R srclib /src /srclib
+RUN chown -R srclib /srclib
 
 USER srclib
-WORKDIR /src
-ENTRYPOINT ["srclib-basic"]
+ENTRYPOINT ["/srclib/srclib-basic/.bin/srclib-basic"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ else
 	GRADLEW = ./gradlew
 endif
 
-.PHONY: default install test test-gen clean dist
+.PHONY: default install test test-gen clean dist docker-image release
 
 default: install
 
@@ -23,3 +23,9 @@ clean:
 
 
 dist: install
+
+docker-image: install
+	docker build -t srclib/srclib-basic .
+
+release: docker-image
+	docker push srclib/srclib-basic


### PR DESCRIPTION
This, along with
https://src.sourcegraph.com/sourcegraph@add-srclib-basic-toolchain,
makes the srclib-basic toolchain work inside Sourcegraph.

Other TODOs are listed at (put link here shortly).
